### PR TITLE
Add per-model cost and percentage stats

### DIFF
--- a/ccusage_monitor.py
+++ b/ccusage_monitor.py
@@ -127,6 +127,21 @@ def create_time_progress_bar(elapsed_minutes, total_minutes, width=50):
     return f"⏰ [{blue}{blue_bar}{red}{red_bar}{reset}] {remaining_time}"
 
 
+# Approximate cost per million tokens for known models
+MODEL_COST_PER_MILLION = {
+    "claude-opus-4": 75.0,
+    "claude-sonnet-4": 15.0,
+}
+
+
+def format_model_usage(model, tokens, total_tokens):
+    """Return formatted percentage, tokens and cost for a model."""
+    percentage = (tokens / total_tokens * 100) if total_tokens > 0 else 0.0
+    cost_per_token = MODEL_COST_PER_MILLION.get(model, 0) / 1_000_000
+    cost = tokens * cost_per_token
+    return f"{percentage:5.1f}% {tokens:,} tokens (${cost:.2f})"
+
+
 def print_header():
     """Print the stylized header with sparkles."""
     cyan = "\033[96m"
@@ -482,8 +497,10 @@ def main():
             )
             if model_usage:
                 print("\n💠 Model Usage:")
+                total_models_tokens = sum(model_usage.values())
                 for m, t in model_usage.items():
-                    print(f"    {m:<15} {t:,} tokens")
+                    summary = format_model_usage(m, t, total_models_tokens)
+                    print(f"    {m:<15} {summary}")
                 print()
             else:
                 print()

--- a/tests/test_model_usage.py
+++ b/tests/test_model_usage.py
@@ -62,3 +62,22 @@ def test_get_session_model_usage_no_match():
     }
     mapping = monitor.get_session_model_usage(active_block, session_info)
     assert mapping == {"claude-opus-4": 75}
+
+
+def test_format_model_usage_summary():
+    tokens = 5000
+    total_tokens = 10000
+    summary = monitor.format_model_usage("claude-opus-4", tokens, total_tokens)
+    expected_cost = tokens * (
+        monitor.MODEL_COST_PER_MILLION["claude-opus-4"] / 1_000_000
+    )
+    expected_cost_str = f"${expected_cost:.2f}"
+    assert "50.0%" in summary
+    assert "5,000" in summary
+    assert expected_cost_str in summary
+
+
+def test_format_model_usage_unknown_model():
+    summary = monitor.format_model_usage("unknown-model", 100, 1000)
+    assert "10.0%" in summary
+    assert "$0.00" in summary


### PR DESCRIPTION
## Summary
- replace progress bars with cost and percentage summary per model
- cover the new format helper in unit tests
- check exact dollar amounts for known and unknown models

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856cf87df048320a34db27dfcb61515