### PR TITLE
Show active Claude model in header

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A beautiful real-time terminal monitoring tool for Claude AI token usage. Track 
 - **⚠️ Warning system** - Alerts when tokens exceed limits or will deplete before session reset
 - **💼 Professional UI** - Clean, colorful terminal interface with emojis
 - **⏰ Customizable scheduling** - Set your own reset times and timezones
+- **🎛 Model awareness** - Automatically displays the active Claude model
 
 ---
 
@@ -267,6 +268,7 @@ The default timezone is **Europe/Warsaw**. Change it to any valid timezone:
 - **Token Progress**: Color-coded bars showing current usage vs limits
 - **Time Progress**: Visual countdown to next session reset
 - **Burn Rate Indicator**: Real-time consumption velocity
+- **Model Awareness**: Displays the active Claude model in the header
 
 #### 🔮 Smart Predictions
 - Calculates when tokens will run out based on current burn rate

--- a/ccusage_monitor.py
+++ b/ccusage_monitor.py
@@ -214,7 +214,18 @@ def format_model_usage(model, tokens, total_tokens):
     return f"{percentage:5.1f}% {tokens:,} tokens (${cost:.2f})"
 
 
-def print_header():
+def format_model_name(model: str | None) -> str | None:
+    """Return a short human readable model name."""
+    if not model:
+        return None
+    if "opus" in model:
+        return "Opus"
+    if "sonnet" in model:
+        return "Sonnet"
+    return model
+
+
+def print_header(active_model: str | None = None):
     """Print the stylized header with sparkles."""
     cyan = "\033[96m"
     blue = "\033[94m"
@@ -225,6 +236,9 @@ def print_header():
 
     print(f"{sparkles}{cyan}CLAUDE TOKEN MONITOR{reset} {sparkles}")
     print(f"{blue}{'=' * 60}{reset}")
+    if active_model:
+        formatted = format_model_name(active_model)
+        print(f"Active Model: {formatted}")
     print()
 
 
@@ -464,6 +478,7 @@ def run_plain(args, token_limit):
 
             # Extract data from active block
             tokens_used = active_block.get("totalTokens", 0)
+            active_model = active_block.get("model")
 
             session_info = run_ccusage_session()
             model_usage = get_session_model_usage(active_block, session_info)
@@ -530,7 +545,7 @@ def run_plain(args, token_limit):
             reset = "\033[0m"
 
             # Display header
-            print_header()
+            print_header(active_model)
 
             # Token Usage section
             print(
@@ -655,6 +670,7 @@ def run_rich(args, token_limit):
                     continue
 
             tokens_used = active_block.get("totalTokens", 0)
+            active_model = active_block.get("model")
             session_info = run_ccusage_session()
             model_usage = get_session_model_usage(active_block, session_info)
 
@@ -717,6 +733,9 @@ def run_rich(args, token_limit):
                 ),
                 Text(f"🔥 Burn Rate: {burn_rate:.1f} tokens/min", style="yellow"),
             ]
+
+            if active_model:
+                body.insert(1, Text(f"Active Model: {format_model_name(active_model)}"))
 
             if model_usage:
                 body.append(Text("\n💠 Model Usage:", style="bold"))

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -1,0 +1,16 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "ccusage_monitor", Path(__file__).resolve().parents[1] / "ccusage_monitor.py"
+)
+assert spec and spec.loader
+monitor = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(monitor)
+
+
+def test_print_header_shows_model(capsys):
+    monitor.print_header("claude-opus-4")
+    captured = capsys.readouterr().out
+    assert "Active Model: Opus" in captured
+


### PR DESCRIPTION
## Summary
- add helper `format_model_name` and show active model in print_header
- include active model info in both plain and rich display modes
- test that the header outputs the formatted model name
- document model awareness feature in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856e53f371c83208254b229c2c91f8c