### PR TITLE
Update setup instructions for ccusage

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ For immediate testing (not recommended for regular use):
 ```bash
 # Install dependencies
 npm install -g ccusage
+ccusage --version  # ensure version is >=0.7.0 for `session --breakdown`
 
 
 # Clone and run
@@ -121,8 +122,10 @@ virtualenv venv
 #### Step-by-Step Setup
 
 ```bash
-# 1. Install ccusage globally
+# 1. Install ccusage globally (requires v0.7.0+ for `session --breakdown`)
 npm install -g ccusage
+# If you already have ccusage installed, upgrade to the latest version
+ccusage --version  # verify version is >=0.7.0
 
 # 2. Clone the repository
 git clone https://github.com/jtn0123/Claude-Code-Usage-Monitor


### PR DESCRIPTION
## Summary
- document that `ccusage session --breakdown` requires version 0.7.0+
- show `ccusage --version` in installation steps

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856eb7a00b88320bc64e213abbbdcd1