### PR TITLE
Add detailed token cost calculation

### DIFF
--- a/tests/test_model_usage.py
+++ b/tests/test_model_usage.py
@@ -31,14 +31,35 @@ def test_get_session_model_usage_by_id():
             {
                 "sessionId": "abc123",
                 "modelBreakdowns": [
-                    {"model": "claude-sonnet-4", "totalTokens": 1000},
-                    {"model": "claude-opus-4", "total": 500},
+                    {
+                        "model": "claude-sonnet-4",
+                        "totalTokens": 1000,
+                        "inputTokens": 600,
+                        "outputTokens": 400,
+                    },
+                    {
+                        "model": "claude-opus-4",
+                        "total": 500,
+                        "inputTokens": 200,
+                        "outputTokens": 300,
+                    },
                 ],
             }
         ]
     }
     mapping = monitor.get_session_model_usage(active_block, session_info)
-    assert mapping == {"claude-sonnet-4": 1000, "claude-opus-4": 500}
+    assert mapping == {
+        "claude-sonnet-4": {
+            "total": 1000,
+            "input_tokens": 600,
+            "output_tokens": 400,
+        },
+        "claude-opus-4": {
+            "total": 500,
+            "input_tokens": 200,
+            "output_tokens": 300,
+        },
+    }
 
 
 def test_get_session_model_usage_no_match():
@@ -51,29 +72,56 @@ def test_get_session_model_usage_no_match():
             {
                 "sessionId": "s1",
                 "lastActivity": "2024-01-01T00:10:00Z",
-                "modelBreakdowns": [{"model": "claude-sonnet-4", "totalTokens": 50}],
+                "modelBreakdowns": [
+                    {
+                        "model": "claude-sonnet-4",
+                        "totalTokens": 50,
+                    }
+                ],
             },
             {
                 "sessionId": "s2",
                 "lastActivity": "2024-01-02T00:20:00Z",
-                "modelBreakdowns": [{"model": "claude-opus-4", "totalTokens": 75}],
+                "modelBreakdowns": [
+                    {
+                        "model": "claude-opus-4",
+                        "totalTokens": 75,
+                    }
+                ],
             },
         ]
     }
     mapping = monitor.get_session_model_usage(active_block, session_info)
-    assert mapping == {"claude-opus-4": 75}
+    assert mapping == {
+        "claude-opus-4": {
+            "total": 75,
+            "input_tokens": None,
+            "output_tokens": None,
+        }
+    }
 
 
 def test_format_model_usage_summary():
     tokens = 5000
     total_tokens = 10000
+    input_tokens = 2000
+    output_tokens = 3000
     pricing = {
         "input_cost_per_token": 0.000015,
         "output_cost_per_token": 0.000075,
     }
     with patch.object(monitor, "get_model_pricing", return_value=pricing):
-        summary = monitor.format_model_usage("claude-opus-4", tokens, total_tokens)
-    expected_cost = tokens * (pricing["input_cost_per_token"] + pricing["output_cost_per_token"]) / 2
+        summary = monitor.format_model_usage(
+            "claude-opus-4",
+            tokens,
+            total_tokens,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+    expected_cost = (
+        input_tokens * pricing["input_cost_per_token"]
+        + output_tokens * pricing["output_cost_per_token"]
+    )
     expected_cost_str = f"${expected_cost:.2f}"
     assert "50.0%" in summary
     assert "5,000" in summary
@@ -85,3 +133,21 @@ def test_format_model_usage_unknown_model():
         summary = monitor.format_model_usage("unknown-model", 100, 1000)
     assert "10.0%" in summary
     assert "$0.00" in summary
+
+
+def test_format_model_usage_average_fallback():
+    tokens = 4000
+    total_tokens = 8000
+    pricing = {
+        "input_cost_per_token": 0.000002,
+        "output_cost_per_token": 0.00001,
+    }
+    with patch.object(monitor, "get_model_pricing", return_value=pricing):
+        summary = monitor.format_model_usage("claude-sonnet-4", tokens, total_tokens)
+    expected_cost = (
+        tokens
+        * (pricing["input_cost_per_token"] + pricing["output_cost_per_token"])
+        / 2
+    )
+    expected_cost_str = f"${expected_cost:.2f}"
+    assert expected_cost_str in summary


### PR DESCRIPTION
## Summary
- support `inputTokens` and `outputTokens` in `get_session_model_usage`
- calculate per-model cost using detailed token counts when available
- update progress bar helpers and loops for new usage format
- expand tests for new cost calculation and fallback logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856edd5975483208e78f47b9a3e5123