### PR TITLE
Run linters, expand line length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 88
+max-line-length = 100
 extend-ignore = E203,W503

--- a/ccusage_monitor.py
+++ b/ccusage_monitor.py
@@ -75,10 +75,7 @@ def get_session_model_usage(active_block, session_info):
         active_start = active_block.get("startTime")
         active_last = active_block.get("lastActivity")
         for s in sessions:
-            if (
-                s.get("startTime") == active_start
-                or s.get("lastActivity") == active_last
-            ):
+            if s.get("startTime") == active_start or s.get("lastActivity") == active_last:
                 target_session = s
                 break
     if not target_session and sessions:
@@ -135,9 +132,7 @@ def create_token_progress_bar(percentage, width=50, plain=False):
 
 def create_time_progress_bar(elapsed_minutes, total_minutes, width=50, plain=False):
     """Create a time progress bar showing time until reset."""
-    percentage = (
-        0 if total_minutes <= 0 else min(100, (elapsed_minutes / total_minutes) * 100)
-    )
+    percentage = 0 if total_minutes <= 0 else min(100, (elapsed_minutes / total_minutes) * 100)
     if plain or not RICH_AVAILABLE:
         filled = int(width * percentage / 100)
         blue_bar = "█" * filled
@@ -198,8 +193,7 @@ def create_model_progress_bar(
 
 # Pricing data source used by the upstream `ccusage` project
 LITELLM_PRICING_URL = (
-    "https://raw.githubusercontent.com/BerriAI/litellm/main/"
-    "model_prices_and_context_window.json"
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/" "model_prices_and_context_window.json"
 )
 
 # Fallback pricing in case fetching from LiteLLM fails
@@ -351,9 +345,7 @@ def calculate_hourly_burn_rate(blocks, current_time):
             # For completed sessions, use actualEndTime or current time
             actual_end_str = block.get("actualEndTime")
             if actual_end_str:
-                session_actual_end = datetime.fromisoformat(
-                    actual_end_str.replace("Z", "+00:00")
-                )
+                session_actual_end = datetime.fromisoformat(actual_end_str.replace("Z", "+00:00"))
             else:
                 session_actual_end = current_time
 
@@ -370,9 +362,7 @@ def calculate_hourly_burn_rate(blocks, current_time):
             continue
 
         # Calculate portion of tokens used in the last hour
-        total_session_duration = (
-            session_actual_end - start_time
-        ).total_seconds() / 60  # minutes
+        total_session_duration = (session_actual_end - start_time).total_seconds() / 60  # minutes
         hour_duration = (
             session_end_in_hour - session_start_in_hour
         ).total_seconds() / 60  # minutes
@@ -386,9 +376,7 @@ def calculate_hourly_burn_rate(blocks, current_time):
     return total_tokens / 60 if total_tokens > 0 else 0
 
 
-def get_next_reset_time(
-    current_time, custom_reset_hour=None, timezone_str="Europe/Warsaw"
-):
+def get_next_reset_time(current_time, custom_reset_hour=None, timezone_str="Europe/Warsaw"):
     """Calculate next token reset time based on fixed 5-hour intervals.
     Default reset times in specified timezone: 04:00, 09:00, 14:00, 18:00, 23:00
     Or use custom reset hour if provided.
@@ -568,17 +556,13 @@ def run_plain(args, token_limit):
                 data["blocks"],
             )
 
-            usage_percentage = (
-                (tokens_used / token_limit) * 100 if token_limit > 0 else 0
-            )
+            usage_percentage = (tokens_used / token_limit) * 100 if token_limit > 0 else 0
             tokens_left = token_limit - tokens_used
 
             # Time calculations
             start_time_str = active_block.get("startTime")
             if start_time_str:
-                start_time = datetime.fromisoformat(
-                    start_time_str.replace("Z", "+00:00")
-                )
+                start_time = datetime.fromisoformat(start_time_str.replace("Z", "+00:00"))
                 current_time = datetime.now(start_time.tzinfo)
             else:
                 pass
@@ -587,9 +571,7 @@ def run_plain(args, token_limit):
             burn_rate = calculate_hourly_burn_rate(data["blocks"], current_time)
 
             # Reset time calculation - use fixed schedule or custom hour with timezone
-            reset_time = get_next_reset_time(
-                current_time, args.reset_hour, args.timezone
-            )
+            reset_time = get_next_reset_time(current_time, args.reset_hour, args.timezone)
 
             # Calculate time to reset
             time_to_reset = reset_time - current_time
@@ -598,9 +580,7 @@ def run_plain(args, token_limit):
             # Predicted end calculation - when tokens will run out based on burn rate
             if burn_rate > 0 and tokens_left > 0:
                 minutes_to_depletion = tokens_left / burn_rate
-                predicted_end_time = current_time + timedelta(
-                    minutes=minutes_to_depletion
-                )
+                predicted_end_time = current_time + timedelta(minutes=minutes_to_depletion)
             else:
                 # If no burn rate or tokens already depleted, use reset time
                 predicted_end_time = reset_time
@@ -765,32 +745,24 @@ def run_rich(args, token_limit):
                 data["blocks"],
             )
 
-            usage_percentage = (
-                (tokens_used / token_limit) * 100 if token_limit > 0 else 0
-            )
+            usage_percentage = (tokens_used / token_limit) * 100 if token_limit > 0 else 0
             tokens_left = token_limit - tokens_used
 
             start_time_str = active_block.get("startTime")
             if start_time_str:
-                start_time = datetime.fromisoformat(
-                    start_time_str.replace("Z", "+00:00")
-                )
+                start_time = datetime.fromisoformat(start_time_str.replace("Z", "+00:00"))
                 current_time = datetime.now(start_time.tzinfo)
             else:
                 current_time = datetime.now()
 
             burn_rate = calculate_hourly_burn_rate(data["blocks"], current_time)
-            reset_time = get_next_reset_time(
-                current_time, args.reset_hour, args.timezone
-            )
+            reset_time = get_next_reset_time(current_time, args.reset_hour, args.timezone)
             time_to_reset = reset_time - current_time
             minutes_to_reset = time_to_reset.total_seconds() / 60
 
             if burn_rate > 0 and tokens_left > 0:
                 minutes_to_depletion = tokens_left / burn_rate
-                predicted_end_time = current_time + timedelta(
-                    minutes=minutes_to_depletion
-                )
+                predicted_end_time = current_time + timedelta(minutes=minutes_to_depletion)
             else:
                 predicted_end_time = reset_time
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.black]
-line-length = 88
+line-length = 100
 
 [tool.flake8]
-max-line-length = 88
+max-line-length = 100
 extend-ignore = ["E203", "W503"]
 
 [tool.mypy]

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -8,7 +8,10 @@ import subprocess
 from unittest.mock import Mock, patch
 import pytest
 
-spec = importlib.util.spec_from_file_location("ccusage_monitor", Path(__file__).resolve().parents[1] / "ccusage_monitor.py")
+spec = importlib.util.spec_from_file_location(
+    "ccusage_monitor",
+    Path(__file__).resolve().parents[1] / "ccusage_monitor.py",
+)
 assert spec and spec.loader
 monitor = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(monitor)
@@ -23,9 +26,7 @@ def test_run_ccusage_success():
 
 
 def test_run_ccusage_failure():
-    with patch(
-        "subprocess.run", side_effect=subprocess.CalledProcessError(1, "ccusage")
-    ):
+    with patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, "ccusage")):
         assert monitor.run_ccusage() is None
 
 
@@ -94,19 +95,13 @@ def test_get_next_reset_time_default():
 def test_get_next_reset_time_custom_hour_next_day():
     current = datetime(2024, 1, 1, 11, 0, tzinfo=ZoneInfo("UTC"))
     expected = datetime(2024, 1, 2, 5, 0, tzinfo=ZoneInfo("UTC"))
-    assert (
-        monitor.get_next_reset_time(current, custom_reset_hour=5, timezone_str="UTC")
-        == expected
-    )
+    assert monitor.get_next_reset_time(current, custom_reset_hour=5, timezone_str="UTC") == expected
 
 
 def test_get_next_reset_time_timezone_conversion():
     current = datetime(2024, 1, 1, 2, 0, tzinfo=ZoneInfo("UTC"))
     expected = datetime(2024, 1, 1, 4, 0, tzinfo=ZoneInfo("UTC"))
-    assert (
-        monitor.get_next_reset_time(current, timezone_str="America/New_York")
-        == expected
-    )
+    assert monitor.get_next_reset_time(current, timezone_str="America/New_York") == expected
 
 
 def test_parse_args(monkeypatch):
@@ -150,5 +145,3 @@ def test_get_token_limit_custom_max_default():
         {"isActive": True, "totalTokens": 8000},
     ]
     assert monitor.get_token_limit("custom_max", blocks) == 7000
-
-

--- a/tests/test_display_modes.py
+++ b/tests/test_display_modes.py
@@ -43,15 +43,11 @@ def test_model_progress_bar_plain_and_rich():
     with patch.object(monitor, "RICH_AVAILABLE", False):
         result = monitor.create_model_progress_bar("claude-opus-4", 50, 100)
         assert isinstance(result, str)
-        result_plain = monitor.create_model_progress_bar(
-            "claude-opus-4", 50, 100, plain=True
-        )
+        result_plain = monitor.create_model_progress_bar("claude-opus-4", 50, 100, plain=True)
         assert isinstance(result_plain, str)
 
     with patch.object(monitor, "RICH_AVAILABLE", True):
         result_rich = monitor.create_model_progress_bar("claude-opus-4", 50, 100)
         assert isinstance(result_rich, Progress)
-        result_plain = monitor.create_model_progress_bar(
-            "claude-opus-4", 50, 100, plain=True
-        )
+        result_plain = monitor.create_model_progress_bar("claude-opus-4", 50, 100, plain=True)
         assert isinstance(result_plain, str)

--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -13,4 +13,3 @@ def test_print_header_shows_model(capsys):
     monitor.print_header("claude-opus-4")
     captured = capsys.readouterr().out
     assert "Active Model: Opus" in captured
-

--- a/tests/test_model_usage.py
+++ b/tests/test_model_usage.py
@@ -145,9 +145,7 @@ def test_format_model_usage_average_fallback():
     with patch.object(monitor, "get_model_pricing", return_value=pricing):
         summary = monitor.format_model_usage("claude-sonnet-4", tokens, total_tokens)
     expected_cost = (
-        tokens
-        * (pricing["input_cost_per_token"] + pricing["output_cost_per_token"])
-        / 2
+        tokens * (pricing["input_cost_per_token"] + pricing["output_cost_per_token"]) / 2
     )
     expected_cost_str = f"${expected_cost:.2f}"
     assert expected_cost_str in summary


### PR DESCRIPTION
## Summary
- run `black`, `flake8`, `mypy` and `pytest`
- configure black/flake8 to use 100 char lines
- remove trailing blank lines and apply formatting

## Testing
- `black --check .`
- `flake8 --exclude=.venv`
- `mypy . --exclude=.venv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f1806ca0832084f910d522e3216f