### PR TITLE
Clarify ccusage CLI requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ A beautiful real-time terminal monitoring tool for Claude AI token usage. Track 
 
 For immediate testing (not recommended for regular use):
 
+> **Note**: The monitor relies on the separate `ccusage` Node CLI. It is not
+> installed via `requirements.txt`. Install it first with `npm install -g ccusage`
+> and ensure the `ccusage` command is available in your `PATH`.
+
 ```bash
 # Install dependencies
 npm install -g ccusage
@@ -130,6 +134,9 @@ ccusage --version  # verify version is >=0.7.0
 # 2. Clone the repository
 git clone https://github.com/jtn0123/Claude-Code-Usage-Monitor
 cd Claude-Code-Usage-Monitor
+
+#  `ccusage` is distributed as a Node package, so it is not listed in
+#  `requirements.txt`. Ensure the CLI remains in your PATH after installation.
 
 # 3. Create virtual environment
 python3 -m venv venv

--- a/tests/test_atoz.py
+++ b/tests/test_atoz.py
@@ -1,0 +1,20 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "ccusage_monitor", Path(__file__).resolve().parents[1] / "ccusage_monitor.py"
+)
+assert spec and spec.loader
+monitor = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(monitor)
+
+
+def test_format_model_name_a_to_z():
+    models = [
+        ("claude-opus-4", "Opus"),
+        ("claude-sonnet-4", "Sonnet"),
+        ("claude-unknown", "claude-unknown"),
+        (None, None),
+    ]
+    for model, expected in models:
+        assert monitor.format_model_name(model) == expected


### PR DESCRIPTION
## Summary
- mention separate ccusage CLI installation in README

## Testing
- `pip install -r requirements.txt`
- `flake8 tests/*.py ccusage_monitor.py`
- `black --check tests/*.py ccusage_monitor.py`
- `pytest -q`
- `python ccusage_monitor.py` *(fails: FileNotFoundError for `ccusage`)*

------
https://chatgpt.com/codex/tasks/task_e_6856f3eaf4c08320b52866671e010c76