### PR TITLE
Add fallback pricing retrieval test

### DIFF
--- a/tests/test_model_usage.py
+++ b/tests/test_model_usage.py
@@ -149,3 +149,10 @@ def test_format_model_usage_average_fallback():
     )
     expected_cost_str = f"${expected_cost:.2f}"
     assert expected_cost_str in summary
+
+
+def test_get_model_pricing_fallback():
+    monitor._PRICING_CACHE = None
+    with patch("urllib.request.urlopen", side_effect=Exception):
+        pricing = monitor.get_model_pricing("claude-opus-4")
+    assert pricing == monitor.DEFAULT_MODEL_PRICING["claude-opus-4"]


### PR DESCRIPTION
## Summary
- add regression test for get_model_pricing fallback behavior

## Testing
- `black .`
- `flake8 --exclude=.venv .`
- `mypy ccusage_monitor.py tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ffd13d2c8320a6423ecc5a725ed4