### PR TITLE
Update docs to Python 3.9+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎯 Claude Code Usage Monitor
 
-[![Python Version](https://img.shields.io/badge/python-3.6+-blue.svg)](https://python.org)
+[![Python Version](https://img.shields.io/badge/python-3.9+-blue.svg)](https://python.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 
@@ -77,7 +77,7 @@ python ccusage_monitor.py
 
 #### Prerequisites
 
-1. **Python 3.6+** installed on your system
+1. **Python 3.9+** installed on your system
 2. **Node.js** for ccusage CLI tool
 
 ### Virtual Environment Setup


### PR DESCRIPTION
## Summary
- bump Python version badge to 3.9+
- update prerequisites to require Python 3.9+

## Testing
- `black .`
- `flake8 --exclude=.venv .`
- `mypy ccusage_monitor.py tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685700148ba48320bb59c983aec3b14e