### PR TITLE
Add pylint configuration

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,5 @@
+[MASTER]
+ignore=.venv
+
+[MESSAGES CONTROL]
+disable=C0114,C0115,C0116

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,5 +42,9 @@ We enforce formatting, style and type checks. Configuration lives in `pyproject.
    ```bash
    mypy ccusage_monitor.py tests
    ```
+4. **Pylint** – run additional static analysis.
+   ```bash
+   pylint ccusage_monitor.py
+   ```
 
 All lint commands should finish with no errors. Run them before committing any code.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ mccabe==0.7.0
 mdurl==0.1.2
 mypy==1.10.0
 mypy_extensions==1.1.0
+pylint==3.1.0
 packaging==25.0
 pathspec==0.12.1
 platformdirs==4.3.8


### PR DESCRIPTION
## Summary
- enable Pylint linting instructions
- include Pylint in dependencies
- provide a minimal `.pylintrc` config

## Testing
- `pytest`
- `black --check .`
- `flake8 --exclude=.venv .`
- `mypy ccusage_monitor.py tests`
- `pylint ccusage_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_685701145f648320ad33a638b8538e45