### PR TITLE
Add cyclomatic complexity linting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,5 +46,9 @@ We enforce formatting, style and type checks. Configuration lives in `pyproject.
    ```bash
    pylint ccusage_monitor.py
    ```
+5. **Radon** – check cyclomatic complexity. Functions should be grade B or better.
+   ```bash
+   radon cc -n B ccusage_monitor.py
+   ```
 
 All lint commands should finish with no errors. Run them before committing any code.

--- a/README.md
+++ b/README.md
@@ -620,6 +620,13 @@ Whether you need help with setup, have feature requests, found a bug, or want to
 
 ---
 
+## Coding Standards
+
+The project enforces linting and complexity checks. Cyclomatic complexity should
+be grade **B** or better as reported by `radon`.
+
+---
+
 ## 📝 License
 
 [MIT License](LICENSE) - feel free to use and modify as needed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,15 @@
+astroid==3.1.0
 black==24.4.2
 click==8.2.1
+dill==0.4.0
 flake8==7.0.0
 iniconfig==2.1.0
+isort==5.13.2
 markdown-it-py==3.0.0
 mccabe==0.7.0
 mdurl==0.1.2
 mypy==1.10.0
 mypy_extensions==1.1.0
-pylint==3.1.0
 packaging==25.0
 pathspec==0.12.1
 platformdirs==4.3.8
@@ -15,6 +17,9 @@ pluggy==1.6.0
 pycodestyle==2.11.1
 pyflakes==3.2.0
 Pygments==2.19.2
+pylint==3.1.0
 pytest==8.2.1
 rich==14.0.0
+tomlkit==0.13.3
 typing_extensions==4.14.0
+radon==6.0.1

--- a/tests/test_model_usage.py
+++ b/tests/test_model_usage.py
@@ -197,5 +197,5 @@ def test_run_rich_once_combined_bar():
     args = Namespace(plan="pro", reset_hour=None, timezone="UTC", plain=False)
     monitor.run_rich_once(args, 7000, data, session_info, console=console)
     output = console.export_text()
-    lines = [l for l in output.splitlines() if "Opus" in l and "Sonnet" in l]
+    lines = [line for line in output.splitlines() if "Opus" in line and "Sonnet" in line]
     assert lines


### PR DESCRIPTION
## Summary
- enforce complexity linting with radon
- require complexity grade B or better in docs
- fix flake8 issue in `test_model_usage.py`

## Testing
- `black --check .`
- `flake8 --exclude=.venv .`
- `mypy ccusage_monitor.py tests`
- `pylint ccusage_monitor.py`
- `pytest`
- `radon cc -n B ccusage_monitor.py`

------
https://chatgpt.com/codex/tasks/task_e_68570c9d80ec8320a31dd63dd234f89b